### PR TITLE
Add QR code styling web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # QR
+
 A smart QR code generator that leverages the Gemini assistant to intelligently design QR codes based on website content and suggest relevant information.
+
+## Web interface
+
+Open `index.html` in your browser to create customized QR codes. Adjust colors, dot style, or add a center image, then download the result as PNG or SVG.
+
+This front-end uses the [qr-code-styling](https://github.com/kozakdenys/qr-code-styling) library.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="ar">
+<head>
+  <meta charset="UTF-8" />
+  <title>مولد رمز QR</title>
+  <link rel="stylesheet" href="styles.css">
+  <script src="https://unpkg.com/qr-code-styling@1.5.0/lib/qr-code-styling.js"></script>
+</head>
+<body>
+  <h1>مولد رمز QR</h1>
+  <div id="qr-code"></div>
+  <form id="controls">
+    <label>النص:
+      <input id="data" type="text" placeholder="أدخل النص" />
+    </label>
+    <label>لون النقاط:
+      <input id="dotColor" type="color" value="#000000" />
+    </label>
+    <label>لون الخلفية:
+      <input id="bgColor" type="color" value="#ffffff" />
+    </label>
+    <label>شكل النقاط:
+      <select id="dotStyle">
+        <option value="square">مربعة</option>
+        <option value="dots">نقاط</option>
+        <option value="rounded">مدورة</option>
+        <option value="extra-rounded">مدورة جدًا</option>
+        <option value="classy">Classy</option>
+        <option value="classy-rounded">Classy Rounded</option>
+      </select>
+    </label>
+    <label>صورة في الوسط:
+      <input id="imageInput" type="file" accept="image/*" />
+    </label>
+    <label>صيغة التحميل:
+      <select id="fileType">
+        <option value="png">PNG</option>
+        <option value="svg">SVG</option>
+      </select>
+    </label>
+    <button id="download">تحميل</button>
+  </form>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,48 @@
+const qrCode = new QRCodeStyling({
+  width: 300,
+  height: 300,
+  type: "svg",
+  data: "",
+  dotsOptions: { color: "#000000", type: "square" },
+  backgroundOptions: { color: "#ffffff" }
+});
+
+qrCode.append(document.getElementById("qr-code"));
+
+const dataInput = document.getElementById("data");
+const dotColorInput = document.getElementById("dotColor");
+const bgColorInput = document.getElementById("bgColor");
+const dotStyleSelect = document.getElementById("dotStyle");
+const imageInput = document.getElementById("imageInput");
+const downloadBtn = document.getElementById("download");
+const fileTypeSelect = document.getElementById("fileType");
+
+function update() {
+  qrCode.update({
+    data: dataInput.value,
+    dotsOptions: { color: dotColorInput.value, type: dotStyleSelect.value },
+    backgroundOptions: { color: bgColorInput.value }
+  });
+}
+
+dataInput.addEventListener("input", update);
+dotColorInput.addEventListener("change", update);
+bgColorInput.addEventListener("change", update);
+dotStyleSelect.addEventListener("change", update);
+
+imageInput.addEventListener("change", () => {
+  const file = imageInput.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    qrCode.update({ image: reader.result });
+  };
+  reader.readAsDataURL(file);
+});
+
+downloadBtn.addEventListener("click", (e) => {
+  e.preventDefault();
+  qrCode.download({ name: "qr-code", extension: fileTypeSelect.value });
+});
+
+update();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,25 @@
+body {
+  font-family: sans-serif;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+#qr-code {
+  margin: 1rem auto;
+  width: 300px;
+  height: 300px;
+}
+
+#controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- create `index.html` with controls to customize QR codes using `qr-code-styling`
- add `script.js` to update and download codes
- include `styles.css` and update README with usage notes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bfc4e2a34832fa8ba3f550f8d5390