### PR TITLE
Add accordion-based QR generator interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,44 +2,77 @@
 <html lang="ar">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="توليد رموز QR مخصصة مع ألوان وصور" />
   <title>مولد رمز QR</title>
   <link rel="stylesheet" href="styles.css">
   <script src="https://unpkg.com/qr-code-styling@1.5.0/lib/qr-code-styling.js"></script>
 </head>
 <body>
-  <h1>مولد رمز QR</h1>
-  <div id="qr-code"></div>
-  <form id="controls">
-    <label>النص:
-      <input id="data" type="text" placeholder="أدخل النص" />
-    </label>
-    <label>لون النقاط:
-      <input id="dotColor" type="color" value="#000000" />
-    </label>
-    <label>لون الخلفية:
-      <input id="bgColor" type="color" value="#ffffff" />
-    </label>
-    <label>شكل النقاط:
-      <select id="dotStyle">
-        <option value="square">مربعة</option>
-        <option value="dots">نقاط</option>
-        <option value="rounded">مدورة</option>
-        <option value="extra-rounded">مدورة جدًا</option>
-        <option value="classy">Classy</option>
-        <option value="classy-rounded">Classy Rounded</option>
-      </select>
-    </label>
-    <label>صورة في الوسط:
-      <input id="imageInput" type="file" accept="image/*" />
-    </label>
-    <label>صيغة التحميل:
-      <select id="fileType">
-        <option value="png">PNG</option>
-        <option value="svg">SVG</option>
-      </select>
-    </label>
-    <button id="download">تحميل</button>
-  </form>
+  <header class="container qr-header">
+    <div class="row row--qr-header">
+      <div class="col qr-logo">
+        <img class="qr-logo__img" src="https://dummyimage.com/60x60/000/fff&text=QR" alt="شعار QR" />
+      </div>
+      <a target="_blank" rel="noopener" class="col white" href="https://www.npmjs.com/package/qr-code-styling">npm</a>
+      <a target="_blank" rel="noopener" class="col white" href="https://github.com/kozakdenys/qr-code-styling">GitHub</a>
+    </div>
+  </header>
+  <main>
+    <section class="container">
+      <div class="row row--body">
+        <form class="col qr-form" id="form">
+          <button type="button" class="accordion accordion--open">الخيارات الأساسية</button>
+          <div class="panel panel--open">
+            <label for="form-data">البيانات</label>
+            <textarea id="form-data">https://qr-code-styling.com</textarea>
+            <label for="form-image-file">ملف الصورة</label>
+            <input id="form-image-file" type="file" />
+            <label for="form-width">العرض</label>
+            <input id="form-width" type="number" min="100" max="10000" value="300" />
+            <label for="form-height">الارتفاع</label>
+            <input id="form-height" type="number" min="100" max="10000" value="300" />
+            <label for="form-margin">الهامش</label>
+            <input id="form-margin" type="number" min="0" max="10000" value="0" />
+          </div>
+          <button type="button" class="accordion">خيارات النقاط</button>
+          <div class="panel">
+            <label for="form-dots-type">نمط النقاط</label>
+            <select id="form-dots-type">
+              <option value="square">مربعة</option>
+              <option value="dots">نقاط</option>
+              <option value="rounded">مدورة</option>
+              <option value="extra-rounded" selected>مدورة جدًا</option>
+              <option value="classy">Classy</option>
+              <option value="classy-rounded">Classy Rounded</option>
+            </select>
+            <label for="form-dots-color">لون النقاط</label>
+            <input id="form-dots-color" type="color" value="#6a1a4c" />
+          </div>
+          <button type="button" class="accordion">خيارات الخلفية</button>
+          <div class="panel">
+            <label for="form-background-color">لون الخلفية</label>
+            <input id="form-background-color" type="color" value="#ffffff" />
+          </div>
+          <div class="options-export-group">
+            <a class="button" id="export-options">تصدير الخيارات كـ JSON</a>
+          </div>
+        </form>
+        <div class="col qr-code-container">
+          <div class="qr-code" id="qr-code"></div>
+          <div class="qr-download-group">
+            <button id="qr-download">تحميل</button>
+            <label class="hide" for="qr-extension">الامتداد</label>
+            <select id="qr-extension">
+              <option value="png" selected>PNG</option>
+              <option value="jpeg">JPEG</option>
+              <option value="svg">SVG</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,48 +1,88 @@
 const qrCode = new QRCodeStyling({
   width: 300,
   height: 300,
-  type: "svg",
-  data: "",
-  dotsOptions: { color: "#000000", type: "square" },
+  data: "https://qr-code-styling.com",
+  dotsOptions: { color: "#6a1a4c", type: "extra-rounded" },
   backgroundOptions: { color: "#ffffff" }
 });
 
 qrCode.append(document.getElementById("qr-code"));
 
-const dataInput = document.getElementById("data");
-const dotColorInput = document.getElementById("dotColor");
-const bgColorInput = document.getElementById("bgColor");
-const dotStyleSelect = document.getElementById("dotStyle");
-const imageInput = document.getElementById("imageInput");
-const downloadBtn = document.getElementById("download");
-const fileTypeSelect = document.getElementById("fileType");
+const dataInput = document.getElementById("form-data");
+const widthInput = document.getElementById("form-width");
+const heightInput = document.getElementById("form-height");
+const marginInput = document.getElementById("form-margin");
+const imageInput = document.getElementById("form-image-file");
+const dotsTypeSelect = document.getElementById("form-dots-type");
+const dotsColorInput = document.getElementById("form-dots-color");
+const bgColorInput = document.getElementById("form-background-color");
+const downloadBtn = document.getElementById("qr-download");
+const extensionSelect = document.getElementById("qr-extension");
+const exportBtn = document.getElementById("export-options");
+
+let imageData = null;
 
 function update() {
   qrCode.update({
     data: dataInput.value,
-    dotsOptions: { color: dotColorInput.value, type: dotStyleSelect.value },
+    width: parseInt(widthInput.value),
+    height: parseInt(heightInput.value),
+    margin: parseInt(marginInput.value),
+    image: imageData,
+    dotsOptions: {
+      type: dotsTypeSelect.value,
+      color: dotsColorInput.value
+    },
     backgroundOptions: { color: bgColorInput.value }
   });
 }
 
-dataInput.addEventListener("input", update);
-dotColorInput.addEventListener("change", update);
-bgColorInput.addEventListener("change", update);
-dotStyleSelect.addEventListener("change", update);
+[dataInput, widthInput, heightInput, marginInput, dotsTypeSelect, dotsColorInput, bgColorInput]
+  .forEach(el => el.addEventListener("input", update));
 
 imageInput.addEventListener("change", () => {
   const file = imageInput.files[0];
-  if (!file) return;
+  if (!file) {
+    imageData = null;
+    update();
+    return;
+  }
   const reader = new FileReader();
   reader.onload = () => {
-    qrCode.update({ image: reader.result });
+    imageData = reader.result;
+    update();
   };
   reader.readAsDataURL(file);
 });
 
 downloadBtn.addEventListener("click", (e) => {
   e.preventDefault();
-  qrCode.download({ name: "qr-code", extension: fileTypeSelect.value });
+  qrCode.download({ name: "qr-code", extension: extensionSelect.value });
+});
+
+exportBtn.addEventListener("click", (e) => {
+  e.preventDefault();
+  const options = {
+    data: dataInput.value,
+    width: parseInt(widthInput.value),
+    height: parseInt(heightInput.value),
+    margin: parseInt(marginInput.value),
+    dotsOptions: { type: dotsTypeSelect.value, color: dotsColorInput.value },
+    backgroundOptions: { color: bgColorInput.value }
+  };
+  const blob = new Blob([JSON.stringify(options, null, 2)], { type: "application/json" });
+  const link = document.createElement("a");
+  link.href = URL.createObjectURL(blob);
+  link.download = "qr-options.json";
+  link.click();
 });
 
 update();
+
+document.querySelectorAll(".accordion").forEach(btn => {
+  btn.addEventListener("click", () => {
+    btn.classList.toggle("accordion--open");
+    const panel = btn.nextElementSibling;
+    panel.classList.toggle("panel--open");
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,29 +1,104 @@
 body {
+  margin: 0;
   font-family: sans-serif;
-  max-width: 600px;
+}
+
+.container {
+  max-width: 960px;
   margin: 0 auto;
   padding: 1rem;
 }
 
-#qr-code {
-  margin: 1rem auto;
-  width: 300px;
-  height: 300px;
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
 }
 
-#controls {
+.col {
+  flex: 1;
+}
+
+.qr-header {
+  background: #333;
+  color: #fff;
+}
+
+.qr-header a {
+  color: #fff;
+  text-decoration: none;
+  padding: 0 0.5rem;
+}
+
+.qr-logo__img {
+  height: 40px;
+}
+
+.row--body {
+  align-items: flex-start;
+}
+
+.qr-form {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
 
-label {
+.qr-code-container {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
+  gap: 1rem;
 }
 
-h1 {
-  text-align: center;
+.qr-code {
+  width: 300px;
+  height: 300px;
+}
+
+.accordion {
+  background-color: #f1f1f1;
+  cursor: pointer;
+  padding: 0.5rem;
+  border: none;
+  text-align: left;
+  outline: none;
+  font-size: 1rem;
+}
+
+.accordion--open {
+  background-color: #ccc;
+}
+
+.panel {
+  display: none;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+}
+
+.panel--open {
+  display: flex;
+}
+
+.qr-download-group {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.hide {
+  display: none;
+}
+
+.options-export-group {
+  margin-top: 1rem;
+}
+
+.button {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background: #6a1a4c;
+  color: #fff;
+  text-decoration: none;
 }


### PR DESCRIPTION
## Summary
- Add header with logo and links to npm and GitHub
- Organize QR settings into accordion sections for main, dots, and background options
- Enable downloading QR codes and exporting options via JSON
- Style layout, accordion, and controls for improved UX

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa53c20748832f9793d66013b29ca0